### PR TITLE
Fixing tests and modifying the testnet program id

### DIFF
--- a/contract/Anchor.toml
+++ b/contract/Anchor.toml
@@ -12,7 +12,7 @@ govcontract = "5BU5KsgU7dpLj6t9tZWy7297rLvpfVHhdTkQrx1MJJ2x"
 govcontract = "AXnkQnEEMBsKcJ1gSXP1aW6tZMGWodzEaoB6b3bRib2r"
 
 [programs.testnet]
-govcontract = "AXnkQnEEMBsKcJ1gSXP1aW6tZMGWodzEaoB6b3bRib2r"
+govcontract = "tGoVgdg8H4pdLZxcSyX3TcKwu7UyPRfq3xoDSEQzW4a"
 
 [registry]
 url = "https://api.apr.dev"

--- a/contract/programs/govcontract/src/lib.rs
+++ b/contract/programs/govcontract/src/lib.rs
@@ -6,7 +6,7 @@ mod utils;
 use anchor_lang::prelude::*;
 use instructions::*;
 
-declare_id!("AXnkQnEEMBsKcJ1gSXP1aW6tZMGWodzEaoB6b3bRib2r");
+declare_id!("tGoVgdg8H4pdLZxcSyX3TcKwu7UyPRfq3xoDSEQzW4a");
 
 #[program]
 pub mod govcontract {

--- a/svmgov/idls/govcontract.json
+++ b/svmgov/idls/govcontract.json
@@ -1,5 +1,5 @@
 {
-  "address": "4igPvJuaCVUCwqaQ3q7L8Y5JL5G1vsDCfLGMMoNthmSt",
+  "address": "tGoVgdg8H4pdLZxcSyX3TcKwu7UyPRfq3xoDSEQzW4a",
   "metadata": {
     "name": "govcontract",
     "version": "0.1.0",

--- a/svmgov/src/main.rs
+++ b/svmgov/src/main.rs
@@ -2,7 +2,6 @@ use anchor_client::anchor_lang::declare_program;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use env_logger;
-use log::debug;
 mod instructions;
 mod utils;
 use utils::{commands, utils::*};

--- a/svmgov/src/utils/utils.rs
+++ b/svmgov/src/utils/utils.rs
@@ -350,7 +350,7 @@ mod tests {
         assert!(result.is_err(), "Expected Err, got {:?}", result);
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Keypair path is required for creating proposal",
+            "No identity keypair path provided. Please specify the path using the --identity_keypair flag.",
             "Unexpected error message"
         );
     }
@@ -362,8 +362,7 @@ mod tests {
         assert!(result.is_err(), "Expected Err, got {:?}", result.as_ref());
         let error_msg = result.as_ref().unwrap_err().to_string();
         assert!(
-            error_msg.contains("No such file or directory")
-                || error_msg.contains("Failed to read keypair file"),
+            error_msg.contains("The specified keypair file does not exist"),
             "Unexpected error message: {}",
             error_msg
         );


### PR DESCRIPTION
There were 2 failing tests for svmgov that should be fixed in this PR. Also, I removed an unused debug log.  

I have a question about the govcontract program id.  Is it common to use the same program id for devnet/testnet/mainnet? Or do teams typically use different programs ids on different clusters?